### PR TITLE
Resolve build warnings and drop unused types

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="vite/client" />
-/// <reference types="cloudflare-turnstile" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
-        "@types/cloudflare-turnstile": "^0.2.2",
         "@types/node": "^24.0.13",
         "@vitejs/plugin-vue": "^6.0.0",
         "@vue/test-utils": "^2.4.6",
@@ -1220,13 +1219,6 @@
       "dependencies": {
         "@types/deep-eql": "*"
       }
-    },
-    "node_modules/@types/cloudflare-turnstile": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@types/cloudflare-turnstile/-/cloudflare-turnstile-0.2.2.tgz",
-      "integrity": "sha512-3Yf7b1Glci+V2bFWwWBbZkRgTuegp7RDgNTOG4U0UNPB9RV4AWvwqg2/qqLff8G+SwKFNXoXvTkqaRBZrAFdKA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "require": "./dist/vue3-turnstile.umd.js",
-      "import": "./dist/vue3-turnstile.es.js",
-      "types": "./dist/types/index.d.ts"
+      "import": "./dist/vue3-turnstile.es.js"
     }
   },
   "type": "module",
@@ -32,18 +32,17 @@
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",
-    "@types/cloudflare-turnstile": "^0.2.2",
     "@types/node": "^24.0.13",
     "@vitejs/plugin-vue": "^6.0.0",
+    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.7.0",
     "eslint": "^9.31.0",
     "eslint-plugin-vue": "~10.3.0",
+    "jsdom": "^26.1.0",
+    "rimraf": "^6.0.1",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
-    "vue-tsc": "^3.0.1",
     "vitest": "^3.2.4",
-    "@vue/test-utils": "^2.4.6",
-    "rimraf": "^6.0.1",
-    "jsdom": "^26.1.0"
+    "vue-tsc": "^3.0.1"
   }
 }

--- a/src/__tests__/TurnstileWidget.spec.ts
+++ b/src/__tests__/TurnstileWidget.spec.ts
@@ -1,6 +1,7 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { TurnstileWidget } from '../index'
+import type { Turnstile } from '../types/turnstile'
 
 vi.mock('@unhead/vue', () => ({
   useScript: () => ({
@@ -10,7 +11,7 @@ vi.mock('@unhead/vue', () => ({
 }))
 
 beforeEach(() => {
-  ;(window as any).turnstile = {
+  ;(window as unknown as { turnstile: Turnstile }).turnstile = {
     render: vi.fn().mockReturnValue('widget-id'),
     reset: vi.fn(),
     remove: vi.fn(),
@@ -20,12 +21,16 @@ beforeEach(() => {
 
 describe('TurnstileWidget', () => {
   it('mounts and exposes methods', async () => {
-    const wrapper = mount(TurnstileWidget, { props: { sitekey: 'test-key', modelValue: null } })
+    const wrapper = mount(TurnstileWidget, {
+      props: { sitekey: 'test-key', modelValue: null },
+    })
     await flushPromises()
-    expect((window as any).turnstile.render).toHaveBeenCalled()
-    expect(typeof (wrapper.vm as any).render).toBe('function')
-    expect(typeof (wrapper.vm as any).reset).toBe('function')
-    expect(typeof (wrapper.vm as any).execute).toBe('function')
-    expect(typeof (wrapper.vm as any).remove).toBe('function')
+    const win = window as unknown as { turnstile: Turnstile }
+    expect(win.turnstile.render).toHaveBeenCalled()
+    const vm = wrapper.vm as InstanceType<typeof TurnstileWidget>
+    expect(typeof vm.render).toBe('function')
+    expect(typeof vm.reset).toBe('function')
+    expect(typeof vm.execute).toBe('function')
+    expect(typeof vm.remove).toBe('function')
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
       external: ['vue', '@unhead/vue'],
       output: {
         exports: 'named',
+        globals: {
+          vue: 'Vue',
+          '@unhead/vue': 'UnheadVue',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- remove unused cloudflare turnstile types
- reorder exports for better node resolution
- define globals in vite config to silence rollup warnings
- clean up tests for strict typings

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873177d39c8832897ba99d9d1e0c768