### PR TITLE
Define Vite env types for Turnstile widget

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,30 @@
 /// <reference types="vite/client" />
+
+import type {
+  AppearanceMode,
+  FailureRetryMode,
+  RefreshExpiredMode,
+  RefreshTimeoutMode,
+  Theme,
+  WidgetSize,
+} from '@/types/turnstile';
+import type { TurnstileLanguage } from '@/TurnstileWidget.vue';
+
+interface ImportMetaEnv {
+  readonly VITE_TURNSTILE_SITEKEY?: string
+  readonly VITE_TURNSTILE_LOGLEVEL?: 'debug' | 'info' | 'warn' | 'error'
+  readonly VITE_TURNSTILE_THEME?: Theme
+  readonly VITE_TURNSTILE_LANGUAGE?: TurnstileLanguage
+  readonly VITE_TURNSTILE_TABINDEX?: number
+  readonly VITE_TURNSTILE_SIZE?: WidgetSize
+  readonly VITE_TURNSTILE_RETRY?: FailureRetryMode
+  readonly VITE_TURNSTILE_RETRY_INTERVAL?: number
+  readonly VITE_TURNSTILE_REFRESH_EXPIRED?: RefreshExpiredMode
+  readonly VITE_TURNSTILE_REFRESH_TIMEOUT?: RefreshTimeoutMode
+  readonly VITE_TURNSTILE_APPEARANCE?: AppearanceMode
+  readonly VITE_TURNSTILE_FEEDBACK_ENABLED?: boolean
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- extend env.d.ts with strongly typed `ImportMetaEnv`
- describe each environment variable used by `TurnstileWidget.vue`

## Testing
- `npm run type`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68731b7d1cec8328a2e8c176fc39320e