### PR TITLE
Add Turnstile plugin export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-export { default as TurnstileWidget } from './TurnstileWidget.vue';
-export type { TurnstileLanguage } from './TurnstileWidget.vue';
+export { default as TurnstileWidget } from './TurnstileWidget.vue'
+export { default as TurnstilePlugin } from './plugin'
+export type { TurnstileLanguage } from './TurnstileWidget.vue'
+export type { RenderParameters, Turnstile } from './types/turnstile'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,13 @@
+import type { App, Plugin } from 'vue'
+import TurnstileWidget from './TurnstileWidget.vue'
+
+/**
+ * Plugin to globally register the TurnstileWidget component.
+ */
+const TurnstilePlugin: Plugin = {
+  install(app: App) {
+    app.component('TurnstileWidget', TurnstileWidget)
+  },
+}
+
+export default TurnstilePlugin


### PR DESCRIPTION
## Summary
- add plugin to register `TurnstileWidget`
- re-export plugin and Turnstile types in the library entry

## Testing
- `npm run lint`
- `npm run type`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68731b882f1483289263626370cde64f