### PR TITLE
Fix vite build output cleanup

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     },
   },
   build: {
+    emptyOutDir: false,
     lib: {
       entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
       name: 'Vue3Turnstile',


### PR DESCRIPTION
## Summary
- keep `dist/types` when rebuilding

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68731bc4be1c8328bff80f5bc2149f09