### PR TITLE
Update package metadata for npm publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/jscarle/vue3-turnstile/actions/workflows/ci.yml/badge.svg)](https://github.com/jscarle/vue3-turnstile/actions/workflows/ci.yml)
 
-A Vue 3 TypeScript Component for Cloudflare's Turnstile
+A Vue 3.5 TypeScript Component for Cloudflare's Turnstile
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -49,5 +49,20 @@
     "vite": "^7.0.4",
     "vitest": "^3.2.4",
     "vue-tsc": "^3.0.1"
+  },
+  "description": "A Vue 3.5 TypeScript Component for Cloudflare's Turnstile.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jscarle/vue3-turnstile.git"
+  },
+  "keywords": [
+    "vue",
+    "turnstile",
+    "captcha",
+    "cloudflare"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- add missing npm package metadata
- update README and description for Vue 3.5

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68731f8336908328a109f8f47935a9fb