### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish to npm when a tag is pushed

## Testing
- `npm run lint`
- `npm test` *(fails: `defineProps()` cannot reference locally declared variables)*
- `npm run build` *(fails: `defineProps()` cannot reference locally declared variables)*

------
https://chatgpt.com/codex/tasks/task_e_687325ed5e848328b6476957bed761c6