### PR TITLE
Add Turnstile plugin options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as TurnstileWidget } from './TurnstileWidget.vue'
-export { default as TurnstilePlugin } from './plugin'
+export { default as TurnstilePlugin, TurnstileOptionsKey } from './plugin'
+export type { TurnstilePluginOptions } from './plugin'
 export type { Language, LogLevel } from './types.ts'
 export type { Theme, WidgetSize, FailureRetryMode, AppearanceMode, RefreshExpiredMode, RefreshTimeoutMode, ExecutionMode } from './turnstile.ts'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,13 +1,45 @@
-import type { App, Plugin } from 'vue'
+import type { App, Plugin, InjectionKey } from 'vue'
 import TurnstileWidget from './TurnstileWidget.vue'
+import type { Language, LogLevel } from './types.ts'
+import type {
+  AppearanceMode,
+  ExecutionMode,
+  FailureRetryMode,
+  RefreshExpiredMode,
+  RefreshTimeoutMode,
+  Theme,
+  WidgetSize,
+} from './turnstile.ts'
+
+export interface TurnstilePluginOptions {
+  sitekey?: string
+  logLevel?: LogLevel
+  language?: Language
+  action?: string
+  cData?: string
+  theme?: Theme
+  tabindex?: number
+  size?: WidgetSize
+  retry?: FailureRetryMode
+  'retry-interval'?: number
+  appearance?: AppearanceMode
+  'refresh-expired'?: RefreshExpiredMode
+  'refresh-timeout'?: RefreshTimeoutMode
+  execution?: ExecutionMode
+  'feedback-enabled'?: boolean
+}
+
+export const TurnstileOptionsKey: InjectionKey<TurnstilePluginOptions> =
+  Symbol('TurnstileOptions')
 
 /**
  * Plugin to globally register the TurnstileWidget component.
  */
-const TurnstilePlugin: Plugin = {
-  install(app: App) {
+const TurnstilePlugin = {
+  install(app: App, options: TurnstilePluginOptions = {}): void {
     app.component('TurnstileWidget', TurnstileWidget)
+    app.provide(TurnstileOptionsKey, options)
   },
-}
+} satisfies Plugin
 
 export default TurnstilePlugin


### PR DESCRIPTION
## Summary
- extend plugin to accept global options and provide them via injection
- expose new helper types and injection key from library entry point

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873318a03008328b37b43bd5cc8fcc8