### PR TITLE
Move widget prop types

### DIFF
--- a/src/TurnstileWidget.vue
+++ b/src/TurnstileWidget.vue
@@ -2,44 +2,13 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useScript } from '@unhead/vue';
 import {
-  type Language,
   type LogLevel,
+  type TurnstileProps,
   TESTING_SITEKEY,
 } from '@/types.ts'
-import {   type RenderParameters,
-  type Turnstile
-} from '@/turnstile.ts'
+import { type RenderParameters } from '@/turnstile.ts'
 import { ENV_DEFAULTS } from '@/setup.ts'
 
-type TurnstileSharedOptions =
-  | 'action'
-  | 'cData'
-  | 'theme'
-  | 'tabindex'
-  | 'size'
-  | 'retry'
-  | 'retry-interval'
-  | 'appearance'
-  | 'refresh-expired'
-  | 'refresh-timeout'
-  | 'execution'
-  | 'feedback-enabled';
-
-type TurnstileProps = Pick<RenderParameters, TurnstileSharedOptions> & {
-  /** Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. */
-  sitekey?: string;
-  /** Log level for browser logs. Can be debug, info, warn, or error. */
-  logLevel?: LogLevel;
-  /** Language to display. Must be either: auto (default) to use the language that the visitor has chosen, or an ISO 639-1 two-letter language code (e.g. en) or language and country code (e.g. en-US). See https://developers.cloudflare.com/turnstile/reference/supported-languages/ */
-  language?: Language;
-};
-
-declare global {
-  // noinspection JSUnusedGlobalSymbols
-  interface Window {
-    turnstile: Turnstile;
-  }
-}
 
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { default as TurnstileWidget } from './TurnstileWidget.vue'
 export { default as TurnstilePlugin, TurnstileOptionsKey } from './plugin'
 export type { TurnstilePluginOptions } from './plugin'
-export type { Language, LogLevel } from './types.ts'
+export type {
+  Language,
+  LogLevel,
+  TurnstileProps,
+  TurnstileSharedOptions,
+} from './types.ts'
 export type { Theme, WidgetSize, FailureRetryMode, AppearanceMode, RefreshExpiredMode, RefreshTimeoutMode, ExecutionMode } from './turnstile.ts'

--- a/src/turnstile.ts
+++ b/src/turnstile.ts
@@ -241,3 +241,12 @@ export interface Turnstile {
    */
   isExpired(container?: string | HTMLElement): boolean;
 }
+
+declare global {
+  // noinspection JSUnusedGlobalSymbols
+  interface Window {
+    turnstile: Turnstile;
+  }
+}
+
+export {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,3 +72,28 @@ export type Language =
 
 export const TESTING_SITEKEY = '1x00000000000000000000AA';
 
+import type { RenderParameters } from './turnstile.ts';
+
+export type TurnstileSharedOptions =
+  | 'action'
+  | 'cData'
+  | 'theme'
+  | 'tabindex'
+  | 'size'
+  | 'retry'
+  | 'retry-interval'
+  | 'appearance'
+  | 'refresh-expired'
+  | 'refresh-timeout'
+  | 'execution'
+  | 'feedback-enabled';
+
+export type TurnstileProps = Pick<RenderParameters, TurnstileSharedOptions> & {
+  /** Every widget has a sitekey. This sitekey is associated with the corresponding widget configuration and is created upon the widget creation. */
+  sitekey?: string;
+  /** Log level for browser logs. Can be debug, info, warn, or error. */
+  logLevel?: LogLevel;
+  /** Language to display. Must be either: auto (default) to use the language that the visitor has chosen, or an ISO 639-1 two-letter language code (e.g. en) or language and country code (e.g. en-US). See https://developers.cloudflare.com/turnstile/reference/supported-languages/ */
+  language?: Language;
+};
+


### PR DESCRIPTION
## Summary
- centralize prop types in `types.ts`
- re-export new types from library entry
- move `Window` augmentation to `turnstile.ts`
- update widget component imports

## Testing
- `npm run lint`
- `npm run type`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687338f32de48328a09d3a60aebc8161