### PR TITLE
Refactor Turnstile plugin typing

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,34 +1,9 @@
 import type { App, Plugin, InjectionKey } from 'vue'
 import TurnstileWidget from './TurnstileWidget.vue'
 import { ENV_DEFAULTS } from './setup.ts'
-import type { Language, LogLevel } from './types.ts'
-import type {
-  AppearanceMode,
-  ExecutionMode,
-  FailureRetryMode,
-  RefreshExpiredMode,
-  RefreshTimeoutMode,
-  Theme,
-  WidgetSize,
-} from './turnstile.ts'
+import type { TurnstileProps } from './types.ts'
 
-export interface TurnstilePluginOptions {
-  sitekey?: string
-  logLevel?: LogLevel
-  language?: Language
-  action?: string
-  cData?: string
-  theme?: Theme
-  tabindex?: number
-  size?: WidgetSize
-  retry?: FailureRetryMode
-  'retry-interval'?: number
-  appearance?: AppearanceMode
-  'refresh-expired'?: RefreshExpiredMode
-  'refresh-timeout'?: RefreshTimeoutMode
-  execution?: ExecutionMode
-  'feedback-enabled'?: boolean
-}
+export type TurnstilePluginOptions = Partial<TurnstileProps>
 
 export const TurnstileOptionsKey: InjectionKey<TurnstilePluginOptions> =
   Symbol('TurnstileOptions')

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,6 +11,7 @@ import {
   type LogLevel,
   TESTING_SITEKEY,
 } from '@/types.ts'
+import type { TurnstileProps } from '@/types.ts'
 
 function parseEnum<T extends string>(val: unknown, valid: readonly T[]): T | undefined {
   return valid.includes(val as T) ? (val as T) : undefined;
@@ -52,4 +53,4 @@ export const ENV_DEFAULTS = {
   appearance: parseEnum<AppearanceMode>(import.meta.env.VITE_TURNSTILE_APPEARANCE, APPEARANCES),
   'feedback-enabled': parseBoolean(import.meta.env.VITE_TURNSTILE_FEEDBACK_ENABLED),
   execution: parseEnum<ExecutionMode>(import.meta.env.VITE_TURNSTILE_EXECUTION, EXECUTION),
-}
+} satisfies Partial<TurnstileProps>


### PR DESCRIPTION
## Summary
- simplify `TurnstilePluginOptions` by reusing `TurnstileProps`
- type `ENV_DEFAULTS` with `Partial<TurnstileProps>`

## Testing
- `npm test`
- `npm run type`


------
https://chatgpt.com/codex/tasks/task_e_68733c34a4a483288cedcb49b8c04c48