### PR TITLE
Improve plugin option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requires **Vue 3.5** or later and **@unhead/vue 2.0.12** or later.
 
 ## Overview
 
-`vue3-turnstile` wraps the [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) widget in a strongly typed Vue component. It exposes the Turnstile API methods as component methods and can be configured via props, plugin defaults, or environment variables.
+`vue3-turnstile` wraps the [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) widget in a strongly typed Vue component. It exposes the Turnstile API methods as component methods and can be configured via component props, environment variables, or plugin defaults. Configuration values are resolved in that order of priority.
 
 ## Installation
 
@@ -76,8 +76,11 @@ import { TurnstilePlugin } from '@jscarle/vue3-turnstile'
 createApp(App).use(TurnstilePlugin).mount('#app')
 ```
 
-The plugin accepts global default options which are applied to every
-`<TurnstileWidget />` instance:
+`TurnstilePlugin` installs the `TurnstileWidget` component globally and injects
+default options for all widget props. Environment variables override these
+plugin options, and component props take priority over both. Options therefore
+serve as fallbacks when neither props nor Vite environment variables provide a
+value for a `<TurnstileWidget />` instance:
 
 ```ts
 createApp(App).use(TurnstilePlugin, {
@@ -88,9 +91,10 @@ createApp(App).use(TurnstilePlugin, {
 
 ### Customization
 
-Global defaults passed to the plugin apply to every widget. Values can also be
-defined through Vite environment variables, allowing configuration per
-deployment:
+Global defaults passed to the plugin apply to every widget but are overridden by
+environment variables. Component props take precedence over both. If an option
+is omitted the component falls back to Vite environment variables, allowing
+configuration per deployment:
 
 ```env
 VITE_TURNSTILE_SITEKEY=your-site-key

--- a/src/TurnstileWidget.vue
+++ b/src/TurnstileWidget.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch, inject } from 'vue';
 import { useScript } from '@unhead/vue';
 import {
   type LogLevel,
@@ -8,11 +8,21 @@ import {
 } from '@/types.ts'
 import { type RenderParameters } from '@/turnstile.ts'
 import { ENV_DEFAULTS } from '@/setup.ts'
+import { TurnstileOptionsKey, type TurnstilePluginOptions } from '@/plugin'
 
 
 
 
 const props = withDefaults(defineProps<TurnstileProps>(), ENV_DEFAULTS);
+const pluginOptions = inject(
+  TurnstileOptionsKey,
+  {} as TurnstilePluginOptions,
+);
+const resolvedProps = computed((): TurnstileProps => ({
+  ...(pluginOptions as TurnstilePluginOptions),
+  ...props,
+}));
+const resolvedSitekey = computed(() => resolvedProps.value.sitekey);
 
 const model = defineModel<string | null>({ required: true });
 
@@ -48,7 +58,9 @@ if (typeof window !== 'undefined' && window.turnstile === undefined) {
 
 /** Check if a message should be logged for the current log level. */
 function isLogLevel(level: LogLevel): boolean {
-  return logLevelOrder[level] >= logLevelOrder[props.logLevel];
+  return (
+    logLevelOrder[level] >= logLevelOrder[resolvedProps.value.logLevel!]
+  );
 }
 
 const callback = (response: string) => {
@@ -76,7 +88,7 @@ const timeoutCallback = () => {
   model.value = null;
 };
 
-const watchedProps = computed((): TurnstileProps => props);
+const watchedProps = computed((): TurnstileProps => resolvedProps.value);
 
 const options = computed((): RenderParameters => {
   const { sitekey, ...rest } = watchedProps.value;
@@ -159,7 +171,7 @@ if (typeof window === 'undefined') {
 defineExpose(exposeDefinition);
 
 onMounted(async () => {
-  if (typeof window === 'undefined' || !props.sitekey) {
+  if (typeof window === 'undefined' || !resolvedProps.value.sitekey) {
     if (isLogLevel('warn')) console.warn('Turnstile site key was not found.');
     isLoading.value = false;
     return;
@@ -185,7 +197,7 @@ watch(
 </script>
 
 <template>
-  <template v-if="sitekey">
+  <template v-if="resolvedSitekey">
     <template v-if="isLoading">
       <slot name="loading">
         <div role="status" aria-busy="true" aria-live="polite">Loading...</div>

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,5 @@
 import type { App, Plugin, InjectionKey } from 'vue'
 import TurnstileWidget from './TurnstileWidget.vue'
-import { ENV_DEFAULTS } from './setup.ts'
 import type { TurnstileProps } from './types.ts'
 
 export type TurnstilePluginOptions = Partial<TurnstileProps>
@@ -15,13 +14,6 @@ const TurnstilePlugin = {
   install(app: App, options: TurnstilePluginOptions = {}): void {
     app.component('TurnstileWidget', TurnstileWidget)
     app.provide(TurnstileOptionsKey, options)
-
-    const defaults = ENV_DEFAULTS as Record<keyof TurnstilePluginOptions, unknown>
-    for (const [key, value] of Object.entries(options) as [keyof TurnstilePluginOptions, unknown][]) {
-      if (value !== undefined) {
-        defaults[key] = value
-      }
-    }
   },
 } satisfies Plugin
 


### PR DESCRIPTION
## Summary
- clarify plugin documentation
- inject plugin options instead of mutating defaults
- ensure component resolves props from plugin options, env variables, then props

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687341be10d8832890c593d53d94af5f