### PR TITLE
Fix parsing of enum environment variables

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -14,7 +14,7 @@ import {
 import type { TurnstileProps } from '@/types.ts'
 
 function parseEnum<T extends string>(val: unknown, valid: readonly T[]): T | undefined {
-  return valid.includes(val as T) ? (val as T) : undefined;
+  return typeof val === 'string' && valid.includes(val as T) ? (val as T) : undefined;
 }
 function parseNumber(val: unknown): number | undefined {
   const n = Number(val);


### PR DESCRIPTION
## Summary
- ensure parseEnum checks values are strings before validating

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687351540a4c832897ddedfce67a6027