### PR TITLE
Add Cloudflare test sitekey constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ VITE_TURNSTILE_SITEKEY=your-site-key
 VITE_TURNSTILE_THEME=light
 ```
 
+### Test sitekeys
+
+The library exports constants for Cloudflare's test sitekeys:
+
+| Constant | Value | Description |
+| --- | --- | --- |
+| `TEST_SITEKEY_ALWAYS_PASS` | `1x00000000000000000000AA` | Always passes (visible) |
+| `TEST_SITEKEY_ALWAYS_BLOCK` | `2x00000000000000000000AB` | Always blocks (visible) |
+| `TEST_SITEKEY_ALWAYS_PASS_INVISIBLE` | `1x00000000000000000000BB` | Always passes (invisible) |
+| `TEST_SITEKEY_ALWAYS_BLOCK_INVISIBLE` | `2x00000000000000000000BB` | Always blocks (invisible) |
+| `TEST_SITEKEY_CHALLENGE` | `3x00000000000000000000FF` | Forces an interactive challenge |
+
 ## Component props
 
 | Prop | Type | Default | Description |

--- a/src/TurnstileWidget.vue
+++ b/src/TurnstileWidget.vue
@@ -4,7 +4,7 @@ import { useScript } from '@unhead/vue';
 import {
   type LogLevel,
   type TurnstileProps,
-  TESTING_SITEKEY,
+  TEST_SITEKEY_ALWAYS_PASS,
 } from '@/types.ts'
 import { type RenderParameters } from '@/turnstile.ts'
 import { ENV_DEFAULTS } from '@/setup.ts'
@@ -95,7 +95,7 @@ const options = computed((): RenderParameters => {
   const { sitekey, logLevel: _logLevel, ...rest } = watchedProps.value;
   void _logLevel;
   return {
-    sitekey: sitekey ?? TESTING_SITEKEY,
+    sitekey: sitekey ?? TEST_SITEKEY_ALWAYS_PASS,
     ...rest,
     callback,
     'error-callback': errorCallback,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,11 @@ export type {
   TurnstileProps,
   TurnstileSharedOptions,
 } from './types.ts'
+export {
+  TEST_SITEKEY_ALWAYS_PASS,
+  TEST_SITEKEY_ALWAYS_BLOCK,
+  TEST_SITEKEY_ALWAYS_PASS_INVISIBLE,
+  TEST_SITEKEY_ALWAYS_BLOCK_INVISIBLE,
+  TEST_SITEKEY_CHALLENGE,
+} from './types.ts'
 export type { Theme, WidgetSize, FailureRetryMode, AppearanceMode, RefreshExpiredMode, RefreshTimeoutMode, ExecutionMode } from './turnstile.ts'

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -9,7 +9,7 @@ import {
 import {
   type Language,
   type LogLevel,
-  TESTING_SITEKEY,
+  TEST_SITEKEY_ALWAYS_PASS,
 } from '@/types.ts'
 import type { TurnstileProps } from '@/types.ts'
 
@@ -40,7 +40,7 @@ const REFRESH_TIMEOUT = ['never', 'manual', 'auto'] as const;
 const EXECUTION = ['render', 'execute'] as const;
 
 export const ENV_DEFAULTS = {
-  sitekey: import.meta.env.VITE_TURNSTILE_SITEKEY ?? TESTING_SITEKEY,
+  sitekey: import.meta.env.VITE_TURNSTILE_SITEKEY ?? TEST_SITEKEY_ALWAYS_PASS,
   logLevel: parseEnum<LogLevel>(import.meta.env.VITE_TURNSTILE_LOGLEVEL, LOG_LEVELS) ?? 'info',
   theme: parseEnum<Theme>(import.meta.env.VITE_TURNSTILE_THEME, THEMES),
   language: parseEnum<Language>(import.meta.env.VITE_TURNSTILE_LANGUAGE, LANGUAGES),

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,20 @@ export type Language =
   | 'th-th'
   | 'tl-ph';
 
-export const TESTING_SITEKEY = '1x00000000000000000000AA';
+/** Test sitekey that always passes (visible). */
+export const TEST_SITEKEY_ALWAYS_PASS = '1x00000000000000000000AA';
+
+/** Test sitekey that always blocks (visible). */
+export const TEST_SITEKEY_ALWAYS_BLOCK = '2x00000000000000000000AB';
+
+/** Test sitekey that always passes (invisible). */
+export const TEST_SITEKEY_ALWAYS_PASS_INVISIBLE = '1x00000000000000000000BB';
+
+/** Test sitekey that always blocks (invisible). */
+export const TEST_SITEKEY_ALWAYS_BLOCK_INVISIBLE = '2x00000000000000000000BB';
+
+/** Test sitekey that forces an interactive challenge (visible). */
+export const TEST_SITEKEY_CHALLENGE = '3x00000000000000000000FF';
 
 import type { RenderParameters } from './turnstile.ts';
 


### PR DESCRIPTION
## Summary
- rename the existing testing sitekey and export all Cloudflare test keys
- document the new constants in the README

## Testing
- `npm run lint`
- `npm test`
- `npm run type`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873547686a48328af2fbf31d1629a40