### PR TITLE
Remove environment variable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requires **Vue 3.5** or later and **@unhead/vue 2.0.12** or later.
 
 ## Overview
 
-`vue3-turnstile` wraps the [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) widget in a strongly typed Vue component. It exposes the Turnstile API methods as component methods and can be configured via component props, environment variables, or plugin defaults. Configuration values are resolved in that order of priority.
+`vue3-turnstile` wraps the [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) widget in a strongly typed Vue component. It exposes the Turnstile API methods as component methods and can be configured via component props or plugin defaults. Component props take precedence over plugin defaults.
 
 ## Installation
 
@@ -44,10 +44,8 @@ createApp(App).use(TurnstilePlugin).mount('#app')
 ```
 
 `TurnstilePlugin` installs the `TurnstileWidget` component globally and injects
-default options for all widget props. Environment variables override these
-plugin options, and component props take priority over both. Options therefore
-serve as fallbacks when neither props nor Vite environment variables provide a
-value for a `<TurnstileWidget />` instance:
+default options for all widget props. Component props take priority over these
+options, which therefore act as fallbacks for each `<TurnstileWidget />` instance:
 
 ```ts
 createApp(App).use(TurnstilePlugin, {
@@ -58,15 +56,8 @@ createApp(App).use(TurnstilePlugin, {
 
 ### Customization
 
-Global defaults passed to the plugin apply to every widget, but are overridden by
-environment variables. Component props take precedence over both. If an option
-is omitted, the component falls back to Vite environment variables, allowing
-configuration per deployment:
-
-```env
-VITE_TURNSTILE_SITEKEY=your-site-key
-VITE_TURNSTILE_THEME=light
-```
+Global defaults passed to the plugin apply to every widget. Component props take
+precedence over these defaults, enabling per-instance configuration.
 
 ### Test sitekeys
 
@@ -140,31 +131,6 @@ function onError(message: string) {
 </template>
 ```
 
-### Environment variables
-When a prop is omitted, its value can be supplied through Vite environment variables.
-The component reads the following variables:
-
-- `VITE_TURNSTILE_SITEKEY`
-- `VITE_TURNSTILE_LOGLEVEL`
-- `VITE_TURNSTILE_THEME`
-- `VITE_TURNSTILE_LANGUAGE`
-- `VITE_TURNSTILE_TABINDEX`
-- `VITE_TURNSTILE_SIZE`
-- `VITE_TURNSTILE_RETRY`
-- `VITE_TURNSTILE_RETRY_INTERVAL`
-- `VITE_TURNSTILE_REFRESH_EXPIRED`
-- `VITE_TURNSTILE_REFRESH_TIMEOUT`
-- `VITE_TURNSTILE_APPEARANCE`
-- `VITE_TURNSTILE_FEEDBACK_ENABLED`
-- `VITE_TURNSTILE_EXECUTION`
-
-Example `.env`:
-
-```env
-VITE_TURNSTILE_SITEKEY=your-site-key
-VITE_TURNSTILE_LOGLEVEL=debug
-VITE_TURNSTILE_THEME=light
-```
 
 ## Token Verification
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,36 +1,5 @@
 /// <reference types="vite/client" />
 
-import type {
-  AppearanceMode,
-  ExecutionMode,
-  FailureRetryMode,
-  RefreshExpiredMode,
-  RefreshTimeoutMode,
-  Theme,
-  WidgetSize,
-} from '@/turnstile.ts';
-import type { Language, LogLevel } from '@/types.ts'
-
-interface ImportMetaEnv {
-  readonly VITE_TURNSTILE_SITEKEY?: string
-  readonly VITE_TURNSTILE_LOGLEVEL?: LogLevel
-  readonly VITE_TURNSTILE_THEME?: Theme
-  readonly VITE_TURNSTILE_LANGUAGE?: Language
-  readonly VITE_TURNSTILE_TABINDEX?: number
-  readonly VITE_TURNSTILE_SIZE?: WidgetSize
-  readonly VITE_TURNSTILE_RETRY?: FailureRetryMode
-  readonly VITE_TURNSTILE_RETRY_INTERVAL?: number
-  readonly VITE_TURNSTILE_REFRESH_EXPIRED?: RefreshExpiredMode
-  readonly VITE_TURNSTILE_REFRESH_TIMEOUT?: RefreshTimeoutMode
-  readonly VITE_TURNSTILE_APPEARANCE?: AppearanceMode
-  readonly VITE_TURNSTILE_FEEDBACK_ENABLED?: boolean
-  readonly VITE_TURNSTILE_EXECUTION?: ExecutionMode
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv
-}
-
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>

--- a/src/TurnstileWidget.vue
+++ b/src/TurnstileWidget.vue
@@ -7,10 +7,10 @@ import {
   TEST_SITEKEY_ALWAYS_PASS,
 } from '@/types.ts'
 import { type RenderParameters } from '@/turnstile.ts'
-import { ENV_DEFAULTS } from '@/setup.ts'
+import { DEFAULT_PROPS } from '@/setup.ts'
 import { TurnstileOptionsKey, type TurnstilePluginOptions } from '@/plugin'
 
-const props = withDefaults(defineProps<TurnstileProps>(), ENV_DEFAULTS);
+const props = withDefaults(defineProps<TurnstileProps>(), DEFAULT_PROPS);
 const pluginOptions = inject(
   TurnstileOptionsKey,
   {} as TurnstilePluginOptions,

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,56 +1,7 @@
-import {
-  type AppearanceMode, type ExecutionMode,
-  type FailureRetryMode,
-  type RefreshExpiredMode,
-  type RefreshTimeoutMode,
-  type Theme,
-  type WidgetSize
-} from '@/turnstile.ts'
-import {
-  type Language,
-  type LogLevel,
-  TEST_SITEKEY_ALWAYS_PASS,
-} from '@/types.ts'
-import type { TurnstileProps } from '@/types.ts'
+import { TEST_SITEKEY_ALWAYS_PASS } from '@/types.ts';
+import type { TurnstileProps } from '@/types.ts';
 
-function parseEnum<T extends string>(val: unknown, valid: readonly T[]): T | undefined {
-  return typeof val === 'string' && valid.includes(val as T) ? (val as T) : undefined;
-}
-function parseNumber(val: unknown): number | undefined {
-  const n = Number(val);
-  return !isNaN(n) ? n : undefined;
-}
-function parseBoolean(val: unknown): boolean | undefined {
-  if (val === undefined) return undefined;
-  if (val === 'true' || val === '1') return true;
-  if (val === 'false' || val === '0') return false;
-  return undefined;
-}
-
-const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
-const THEMES = ['auto', 'light', 'dark'] as const;
-const LANGUAGES = [
-  'auto','ar','bn','bg','ca','zh-CN','zh-TW','hr','cs','da','nl','en','et','tl','fi','fr','de','el','he','hi','hu','id','it','ja','ko','lv','lt','ms','nb','fa','pl','pt','pt-BR','ro','ru','sr','sk','sl','es','sv','th','tr','uk','vi','ar-eg','es-es','fr-fr','de-de','ja-jp','ru-ru','tr-tr','pt-br','nl-nl','it-it','pl-pl','fa-ir','hr-hr','hu-hu','lt-lt','nb-no','ro-ro','sk-sk','sl-si','sr-ba','uk-ua','ms-my','th-th','tl-ph'
-] as const;
-const SIZES = ['normal', 'compact', 'flexible'] as const;
-const FAILURE_MODES = ['never', 'auto'] as const;
-const APPEARANCES = ['always', 'execute', 'interaction-only'] as const;
-const REFRESH_EXPIRED = ['never', 'manual', 'auto'] as const;
-const REFRESH_TIMEOUT = ['never', 'manual', 'auto'] as const;
-const EXECUTION = ['render', 'execute'] as const;
-
-export const ENV_DEFAULTS = {
-  sitekey: import.meta.env.VITE_TURNSTILE_SITEKEY ?? TEST_SITEKEY_ALWAYS_PASS,
-  logLevel: parseEnum<LogLevel>(import.meta.env.VITE_TURNSTILE_LOGLEVEL, LOG_LEVELS) ?? 'info',
-  theme: parseEnum<Theme>(import.meta.env.VITE_TURNSTILE_THEME, THEMES),
-  language: parseEnum<Language>(import.meta.env.VITE_TURNSTILE_LANGUAGE, LANGUAGES),
-  tabindex: parseNumber(import.meta.env.VITE_TURNSTILE_TABINDEX),
-  size: parseEnum<WidgetSize>(import.meta.env.VITE_TURNSTILE_SIZE, SIZES),
-  retry: parseEnum<FailureRetryMode>(import.meta.env.VITE_TURNSTILE_RETRY, FAILURE_MODES),
-  'retry-interval': parseNumber(import.meta.env.VITE_TURNSTILE_RETRY_INTERVAL),
-  'refresh-expired': parseEnum<RefreshExpiredMode>(import.meta.env.VITE_TURNSTILE_REFRESH_EXPIRED, REFRESH_EXPIRED),
-  'refresh-timeout': parseEnum<RefreshTimeoutMode>(import.meta.env.VITE_TURNSTILE_REFRESH_TIMEOUT, REFRESH_TIMEOUT),
-  appearance: parseEnum<AppearanceMode>(import.meta.env.VITE_TURNSTILE_APPEARANCE, APPEARANCES),
-  'feedback-enabled': parseBoolean(import.meta.env.VITE_TURNSTILE_FEEDBACK_ENABLED),
-  execution: parseEnum<ExecutionMode>(import.meta.env.VITE_TURNSTILE_EXECUTION, EXECUTION),
-} satisfies Partial<TurnstileProps>
+export const DEFAULT_PROPS: Partial<TurnstileProps> = {
+  sitekey: TEST_SITEKEY_ALWAYS_PASS,
+  logLevel: 'info',
+};


### PR DESCRIPTION
## Summary
- Default widget props now use test key and info-level logging without reading from `import.meta.env`
- Simplify component defaults and remove environment variable references in documentation
- Drop custom environment variable typings

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890fe95cb448328a7d490736b20ba9e