### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vue3-turnstile
 
-A Vue 3.5 TypeScript component for Cloudflare's Turnstile.
+A Vue 3.5.17 TypeScript component for Cloudflare's Turnstile.
 
-Requires **Vue 3.5** or later and **@unhead/vue 2.0.12** or later.
+Requires **Vue 3.5.17** or later and **@unhead/vue 2.0.12** or later.
 
 [![CI](https://github.com/jscarle/vue3-turnstile/actions/workflows/ci.yml/badge.svg)](https://github.com/jscarle/vue3-turnstile/actions/workflows/ci.yml)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jscarle/vue3-turnstile",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jscarle/vue3-turnstile",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jscarle/vue3-turnstile",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Vue 3.5 TypeScript component for Cloudflare's Turnstile.",
   "private": false,
   "main": "./dist/vue3-turnstile.umd.js",


### PR DESCRIPTION
## Summary
- bump package version to 1.0.2
- document current peer dependency versions in README

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891145175f08328a3e51732b89c3357