### PR TITLE
fix: avoid render loop on model updates

### DIFF
--- a/src/TurnstileWidget.vue
+++ b/src/TurnstileWidget.vue
@@ -15,10 +15,17 @@ const pluginOptions = inject(
   TurnstileOptionsKey,
   {} as TurnstilePluginOptions,
 );
-const resolvedProps = computed((): TurnstileProps => ({
-  ...(pluginOptions as TurnstilePluginOptions),
-  ...props,
-}));
+const resolvedProps = computed((): TurnstileProps => {
+  // Exclude modelValue to prevent watch loops when the v-model changes
+  const { modelValue: _modelValue, ...propsWithoutModel } = props as TurnstileProps & {
+    modelValue?: unknown
+  };
+  void _modelValue;
+  return {
+    ...(pluginOptions as TurnstilePluginOptions),
+    ...propsWithoutModel,
+  };
+});
 const resolvedSitekey = computed(() => resolvedProps.value.sitekey);
 
 const model = defineModel<string | null>({ required: true });

--- a/src/TurnstileWidget.vue
+++ b/src/TurnstileWidget.vue
@@ -10,7 +10,7 @@ import { type RenderParameters } from '@/turnstile.ts'
 import { DEFAULT_PROPS } from '@/setup.ts'
 import { TurnstileOptionsKey, type TurnstilePluginOptions } from '@/plugin'
 
-const props = withDefaults(defineProps<TurnstileProps>(), DEFAULT_PROPS);
+const props = defineProps<TurnstileProps>();
 const pluginOptions = inject(
   TurnstileOptionsKey,
   {} as TurnstilePluginOptions,
@@ -22,9 +22,12 @@ const resolvedProps = computed((): TurnstileProps => {
   };
   void _modelValue;
   return {
+    ...DEFAULT_PROPS,
     ...(pluginOptions as TurnstilePluginOptions),
-    ...propsWithoutModel,
-  };
+    ...Object.fromEntries(
+      Object.entries(propsWithoutModel).filter(([, v]) => v !== undefined),
+    ),
+  } as TurnstileProps;
 });
 const resolvedSitekey = computed(() => resolvedProps.value.sitekey);
 

--- a/src/__tests__/TurnstileWidget.spec.ts
+++ b/src/__tests__/TurnstileWidget.spec.ts
@@ -1,6 +1,6 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { TurnstileWidget } from '../index'
+import { TurnstileWidget, TurnstileOptionsKey } from '../index'
 import type { Turnstile } from '../turnstile.ts'
 
 vi.mock('@unhead/vue', () => ({
@@ -44,5 +44,26 @@ describe('TurnstileWidget', () => {
     await wrapper.setProps({ modelValue: 'token' })
     await flushPromises()
     expect(renderSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses provided options as defaults', async () => {
+    const win = window as unknown as { turnstile: Turnstile }
+    const renderSpy = vi.spyOn(win.turnstile, 'render')
+    mount(TurnstileWidget, {
+      props: { modelValue: null },
+      global: {
+        provide: {
+          [TurnstileOptionsKey]: {
+            sitekey: 'plugin-key',
+            theme: 'dark',
+          },
+        },
+      },
+    })
+    await flushPromises()
+    expect(renderSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sitekey: 'plugin-key', theme: 'dark' }),
+    )
   })
 })

--- a/src/__tests__/TurnstileWidget.spec.ts
+++ b/src/__tests__/TurnstileWidget.spec.ts
@@ -33,4 +33,16 @@ describe('TurnstileWidget', () => {
     expect(typeof vm.execute).toBe('function')
     expect(typeof vm.remove).toBe('function')
   })
+
+  it('does not re-render when modelValue changes', async () => {
+    const wrapper = mount(TurnstileWidget, {
+      props: { sitekey: 'test-key', modelValue: null },
+    })
+    await flushPromises()
+    const win = window as unknown as { turnstile: Turnstile }
+    const renderSpy = vi.spyOn(win.turnstile, 'render')
+    await wrapper.setProps({ modelValue: 'token' })
+    await flushPromises()
+    expect(renderSpy).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Summary
- prevent `TurnstileWidget` from re-rendering when v-model changes
- add regression test for model updates

## Testing
- `npm test`
- `npm run lint`
- `npm run type`


------
https://chatgpt.com/codex/tasks/task_e_68914ce19674832892ebe2b71386b986